### PR TITLE
Update for Linux and Mac instructions

### DIFF
--- a/README-Linux.md
+++ b/README-Linux.md
@@ -1,0 +1,99 @@
+[Top-level README](README.md)
+
+### Linux manual installation
+1. If you did not use the DEB package, make sure you have installed these packages from repositories:
+  - Either of these web servers is recommended (you may run *I, Librarian* with any web server)
+    * **apache2 (may be named httpd)**
+    * **nginx**
+  - PHP (*I, Librarian* requires PHP 7.2+)
+    * For Apache, **php** and **libapache2-mod-php**
+    * For Nginx, **php-fpm** is recommended.
+  - PHP Extensions
+    * **php-sqlite3**: SQLite database for PHP.
+    * **php-gd**, **php-curl**, **php-intl**, **php-xml**, **php-json**, **php-mbstring**, **php-zip**: Other required PHP extensions.
+    * **php-ldap**: Required for using LDAP.
+  - External Utilities
+    * **poppler-utils**: required for PDF indexing and for the built-in PDF viewer.
+    * **ghostscript**: required for the built-in PDF viewer.
+    * **tesseract-ocr**: optional OCR.
+    * **libreoffice**: optional import of office files.
+
+2. If you are installing from the tar.gz, login as `root` or use `sudo`, and extract files
+  into a directory underneath the web server's root directory (e.g. `/var/www/librarian`). Example:
+
+```bash
+  tar -Jxf I-Librarian-*.tar.xz -C /var/www/librarian
+```
+3. Change the owner of the `data` sub-folder to the account that runs the web server. For Apache, this is usually `www-data`
+and for Nginx, `nobody`. Example:
+
+```bash
+  chown -R www-data:www-data /var/www/librarian/data
+```
+
+4. Configure the web server appropriately:
+
+ * Apache: Insert a setting like this example into the configuration file:
+
+```apache_conf
+Alias /librarian "/var/www/librarian/public"
+<Directory "/var/www/librarian/public">
+    AllowOverride All
+    # Allow access from this computer
+    Require local
+    # Allow access from intranet computers
+    Require ip 10
+    Require ip 172.16 172.17 172.18 172.19 172.20
+    Require ip 172.21 172.22 172.23 172.24 172.25
+    Require ip 172.26 172.27 172.28 172.29 172.30 172.31
+    Require ip 192.168
+    # Insert Allow from directives here to allow access from the internet
+    # "Require all granted" opens access to everybody
+</Directory>
+```
+
+You may wish to alter who has access (e.g. to allow access from more IP numbers or domain names) - see the Apache [Authentication and Authorization HOWTO](https://httpd.apache.org/docs/2.4/howto/auth.html) for details.
+
+ * Nginx: Add a block like this example to the `server` section:  (/var/www is assumed to be the root of the web server)
+
+```nginx.conf
+# if no directives, then access from all IPs is enabled
+allow 127.0.0.1;
+allow 10.0.0.0/8;
+allow 172.16.0.0/16;
+deny all;   # catch-all that denies everything else
+
+location /library {
+  # Ensures the URL `/library/` executes index.php
+  index index.php;
+
+  location ~ ^(.+\.php)(.*)$ {
+    alias /var/www/library/public;
+    fastcgi_split_path_info ^/library(.+\.php)(.*)$ ;
+    fastcgi_pass   127.0.0.1:9000;
+    include        fastcgi.conf;
+    fastcgi_param PATH_INFO $fastcgi_path_info;
+  }
+
+  # Maps the URL `/library/` to the correct file system location
+  alias /var/www/library/public;
+  try_files $uri $uri/ =404;
+}
+```
+
+PHP-FPM must also be configured. Locate where the configuration files are (e.g. /etc/php or /etc/php74) and 
+
+  a. Copy php.ini-production to php.ini (if it does not exist)
+  b. In php.ini, ensure cgi.fix_pathinfo=1 and configure important settings as needed (e.g. max_execution_time, max_input_time, memory_limit)
+  c. In php.ini, enable the installed extensions in the ``Dynamic Extensions`` section (e.g. extension=curl, no semicolon)
+  d. Double check and configure the file php-fpm.conf as desired
+  e. In the directory php-fpm.d, copy the example `www.conf.default` to `www.conf`
+  f. Edit and configure this new file which sets up the www pool
+     - `User` and `Group` should match the account running the PHP process
+     - `listen` should equal the setting in nginx.conf (e.g. listen = 127.0.0.1:9000)
+
+**A common source of problems is incorrect permissions and ownership - the web server and PHP must be able to read and execute the files**
+
+5. Restart the web server (and also php-fpm if needed)
+6. You can access your library in a browser at http://127.0.0.1/librarian
+

--- a/README-Linux.md
+++ b/README-Linux.md
@@ -83,14 +83,14 @@ location /library {
 
 PHP-FPM must also be configured. Locate where the configuration files are (e.g. /etc/php or /etc/php74) and 
 
-  a. Copy php.ini-production to php.ini (if it does not exist)
-  b. In php.ini, ensure cgi.fix_pathinfo=1 and configure important settings as needed (e.g. max_execution_time, max_input_time, memory_limit)
-  c. In php.ini, enable the installed extensions in the ``Dynamic Extensions`` section (e.g. extension=curl, no semicolon)
-  d. Double check and configure the file php-fpm.conf as desired
-  e. In the directory php-fpm.d, copy the example `www.conf.default` to `www.conf`
-  f. Edit and configure this new file which sets up the www pool
-     - `User` and `Group` should match the account running the PHP process
-     - `listen` should equal the setting in nginx.conf (e.g. listen = 127.0.0.1:9000)
+   1. Copy php.ini-production to php.ini (if it does not exist)  
+   2. In php.ini, ensure cgi.fix_pathinfo=1 and configure important settings as needed (e.g. max_execution_time, max_input_time, memory_limit)  
+   3. In php.ini, enable the installed extensions in the ``Dynamic Extensions`` section (e.g. extension=curl, no semicolon)  
+   4. Double check and configure the file php-fpm.conf as desired  
+   5. In the directory php-fpm.d, copy the example `www.conf.default` to `www.conf`  
+   6. Edit and configure this new file which sets up the www pool  
+     - `User` and `Group` should match the account running the PHP process  
+     - `listen` should equal the setting in nginx.conf (e.g. listen = 127.0.0.1:9000)  
 
 **A common source of problems is incorrect permissions and ownership - the web server and PHP must be able to read and execute the files**
 

--- a/README-Linux.md
+++ b/README-Linux.md
@@ -95,5 +95,6 @@ PHP-FPM must also be configured. Locate where the configuration files are (e.g. 
 **A common source of problems is incorrect permissions and ownership - the web server and PHP must be able to read and execute the files**
 
 5. Restart the web server (and also php-fpm if needed)
+
 6. You can access your library in a browser at http://127.0.0.1/librarian
 

--- a/README-Linux.md
+++ b/README-Linux.md
@@ -11,7 +11,8 @@
   - PHP Extensions
     * **php-sqlite3**: SQLite database for PHP.
     * **php-gd**, **php-curl**, **php-intl**, **php-xml**, **php-json**, **php-mbstring**, **php-zip**: Other required PHP extensions.
-    * **php-ldap**: Required for using LDAP.
+    * **php-ldap**: Required if using LDAP.
+    * **php-sodium**: Encryption related requirement
   - External Utilities
     * **poppler-utils**: required for PDF indexing and for the built-in PDF viewer.
     * **ghostscript**: required for the built-in PDF viewer.

--- a/README-Mac.md
+++ b/README-Mac.md
@@ -2,13 +2,13 @@
 
 ### Mac OS X manual installation
 
-If you are comfortable with Terminal and the command line, it is highly recommeded that you use [Homebrew](https://brew.sh/) or [MacPorts](https://www.macports.org/) to enable the use of UNIX based software on your Mac. In this case, the Linux instructions can be followed with paths modified as needed (Standard Macport installations live at /opt/local (e.g. /opt/local/var/www, not /var/www) while Brew lives at /usr/local  
+If you are comfortable with Terminal and the command line, it is highly recommeded that you use [Homebrew](https://brew.sh/) or [MacPorts](https://www.macports.org/) to enable the use of UNIX based software on your Mac. In this case, the Linux instructions can be followed with paths modified as needed (Standard Macport installations live at /opt/local (e.g. /opt/local/var/www, not /var/www) while Brew lives at /usr/local )
 
-The PHP extension Sodium will also be needed (php72-sodium, php73-sodium, or php74-sodium) as it is non-standard.
+The PHP extension Sodium will also be useful (php72-sodium, php73-sodium, or php74-sodium) as it is non-standard.
 
-If you want a standalone installation, you will need to have an Apache + PHP stack installed. Details may vary depending on which PHP stack you are using.
+If you want a standalone installation, you will need to have an Apache + PHP stack installed. Details may vary depending on which PHP stack you are using. One option is to install [MAMP](https://www.mamp.info/en/mac/) but it comes with MySQL as well. To configure a MAMP based installation, the Linux instructions can be followed.
 
-Prior to Mac OS 10.10.1 (Yosemite), the default install of Mac OS included Apache and PHP built with the GD library. However, the PHP installed with Yosemite does not include GD, so you will need to install one that does: it is simplest to use the one line installation instructions at [http://php-osx.liip.ch/](http://php-osx.liip.ch/.). PHP also needs to be upgraded to 7.2 or above.
+If you want to use the Apache server OS X comes with, then a new version of PHP is needed. Prior to Mac OS 10.10.1 (Yosemite), the default install of Mac OS included Apache and PHP built with the GD library. However, the PHP installed with Yosemite does not include GD, so you will need to install one that does: it is simplest to use the one line installation instructions at [http://php-osx.liip.ch/](http://php-osx.liip.ch/.). PHP also needs to be upgraded to 7.2 or above.
 
 Warning: there are potential headaches with using the built-in Apache on 10.14+ and custom PHP modules due to Apple specific issues. Read through https://php-osx.liip.ch/ extensively (specifically [here](https://github.com/liip/php-osx/issues/249)).
 
@@ -49,19 +49,3 @@ Alias /librarian /Users/yourusername/librarian/public
 * Change the owner of the `data` sub-folder to the Apache user (_www for the default install). You can do this at the Terminal: `chown -R _www ~/librarian/data`.)
 * Open your web browser and go to [http://127.0.0.1/librarian](http://127.0.0.1/librarian).
 
-### First use
-* Note on security: These installation instructions allow access to your library only from local computer
-  or an internal network.
-* In order to start *I, Librarian*, open your web browser, and visit:
-  [http://127.0.0.1/librarian](http://127.0.0.1/librarian)
-* Replace `127.0.0.1` with your static IP, or qualified server domain name, if you have either one.
-* Migrate your previous library, or create an account and head to `Administrator > Software details` to see if everything checks fine.
-* You should also check `Administrator > Global settings` to run *I, Librarian* the way you want.
-
-**Thank you for using *I, Librarian*!**
-
-### Un-installation
-* If you used the DEB package, execute the `uninstall.sh` un-installer.
-* Otherwise un-install all programs that you installed solely to use *I, Librarian*.
-* These may include Apache and PHP. **Note: You might have other programs using these. Only remove if sure.**
-* Delete *I, Librarian* directory.

--- a/README-Mac.md
+++ b/README-Mac.md
@@ -1,0 +1,63 @@
+[Top-level README](README.md)
+
+### Mac OS X manual installation
+
+If you are comfortable with Terminal and the command line, it is recommeded to use [Homebrew](https://brew.sh/) or [MacPorts](https://www.macports.org/) to enable the use of UNIX based software on your Mac. In this case, the Linux instructions can be followed with paths adjusted as needed (e.g. /opt/local/var/www instead of /var/www).  The PHP extension Sodium will also be needed (php72-sodium, php73-sodium, or php74-sodium).
+
+If you want a standalone installation, you will need to have an Apache + PHP stack installed. Details may vary depending on which PHP stack you are using.
+
+Prior to Mac OS 10.10.1 (Yosemite), the default install of Mac OS included Apache and PHP built with the GD library. However, the PHP installed with Yosemite does not include GD, so you will need to install one that does: it is simplest to use the one line installation instructions at [http://php-osx.liip.ch/](http://php-osx.liip.ch/.).
+
+Warning: there are potential headaches with using the built-in Apache on 10.14+ and custom PHP modules due to Apple related security "quirks". Read through https://php-osx.liip.ch/ extensively.
+
+Edit /etc/apache2/httpd.conf using a text editor (e.g. TextEdit). You must make two changes:
+
+* Enabling php, by removing the initial hash symbol from the line beginning "#LoadModule php5_module" (pre-yosemite), or adding a similar line with the path to wherever you installed PHP, eg:
+    
+    LoadModule php5_module    /usr/local/php5-5.3.29-20141019-211753/libphp5.so
+
+* Additional PHP extensions, like **php-sqlite3 php-gd php-curl php-xml php-intl php-json php-mbstring php-zip** may need to be installed.
+
+* Adding a new Directory directive, by inserting: 
+
+```apache_conf
+Alias /librarian /Users/yourusername/librarian/public
+<Directory /Users/Yourusername/librarian/public>
+    AllowOverride All
+    # Allow access from this computer
+    Require local
+    # Allow access from intranet computers
+    Require ip 10
+    Require ip 172.16 172.17 172.18 172.19 172.20
+    Require ip 172.21 172.22 172.23 172.24 172.25
+    Require ip 172.26 172.27 172.28 172.29 172.30 172.31
+    Require ip 192.168
+    # Insert Allow from directives here to allow access from the internet
+    # "Require all granted" opens access to everybody
+</Directory>
+```
+* Don't forget to change "yourusername" to your actual user name. You can find out your user name by typing `whoami` in Terminal.
+* You may wish to alter who has access (e.g. to allow access from more IP numbers or domain names) - see the Apache [Authentication and Authorization HOWTO](https://httpd.apache.org/docs/2.4/howto/auth.html) for details.
+* Restart Apache, by typing `sudo apachectl restart` in Terminal
+* Install LibreOffice, Tesseract OCR, Ghostscript, and Poppler.
+* Download *I, Librarian* source for Linux and double-click the file to extract its contents. Rename the extracted directory to 'librarian' and move it to your folder.
+* Make sure that the directory is accessible to *Others*. Use the `Get Info` dialog of the *Sites* directory to change permissions for *Everyone* to access and read (alternatively, run `chmod o+r ~/Sites/` at the terminal). You also need to make sure *Everyone* has **Execute** permissions for your home directory.
+* Change the owner of the `data` sub-folder to the Apache user (_www for the default install). You can do this at the Terminal: `chown -R _www ~/librarian/data`.)
+* Open your web browser and go to [http://127.0.0.1/librarian](http://127.0.0.1/librarian).
+
+### First use
+* Note on security: These installation instructions allow access to your library only from local computer
+  or an internal network.
+* In order to start *I, Librarian*, open your web browser, and visit:
+  [http://127.0.0.1/librarian](http://127.0.0.1/librarian)
+* Replace `127.0.0.1` with your static IP, or qualified server domain name, if you have either one.
+* Migrate your previous library, or create an account and head to `Administrator > Software details` to see if everything checks fine.
+* You should also check `Administrator > Global settings` to run *I, Librarian* the way you want.
+
+**Thank you for using *I, Librarian*!**
+
+### Un-installation
+* If you used the DEB package, execute the `uninstall.sh` un-installer.
+* Otherwise un-install all programs that you installed solely to use *I, Librarian*.
+* These may include Apache and PHP. **Note: You might have other programs using these. Only remove if sure.**
+* Delete *I, Librarian* directory.

--- a/README-Mac.md
+++ b/README-Mac.md
@@ -2,21 +2,23 @@
 
 ### Mac OS X manual installation
 
-If you are comfortable with Terminal and the command line, it is recommeded to use [Homebrew](https://brew.sh/) or [MacPorts](https://www.macports.org/) to enable the use of UNIX based software on your Mac. In this case, the Linux instructions can be followed with paths adjusted as needed (e.g. /opt/local/var/www instead of /var/www).  The PHP extension Sodium will also be needed (php72-sodium, php73-sodium, or php74-sodium).
+If you are comfortable with Terminal and the command line, it is highly recommeded that you use [Homebrew](https://brew.sh/) or [MacPorts](https://www.macports.org/) to enable the use of UNIX based software on your Mac. In this case, the Linux instructions can be followed with paths modified as needed (Standard Macport installations live at /opt/local (e.g. /opt/local/var/www, not /var/www) while Brew lives at /usr/local  
+
+The PHP extension Sodium will also be needed (php72-sodium, php73-sodium, or php74-sodium) as it is non-standard.
 
 If you want a standalone installation, you will need to have an Apache + PHP stack installed. Details may vary depending on which PHP stack you are using.
 
-Prior to Mac OS 10.10.1 (Yosemite), the default install of Mac OS included Apache and PHP built with the GD library. However, the PHP installed with Yosemite does not include GD, so you will need to install one that does: it is simplest to use the one line installation instructions at [http://php-osx.liip.ch/](http://php-osx.liip.ch/.).
+Prior to Mac OS 10.10.1 (Yosemite), the default install of Mac OS included Apache and PHP built with the GD library. However, the PHP installed with Yosemite does not include GD, so you will need to install one that does: it is simplest to use the one line installation instructions at [http://php-osx.liip.ch/](http://php-osx.liip.ch/.). PHP also needs to be upgraded to 7.2 or above.
 
-Warning: there are potential headaches with using the built-in Apache on 10.14+ and custom PHP modules due to Apple related security "quirks". Read through https://php-osx.liip.ch/ extensively.
+Warning: there are potential headaches with using the built-in Apache on 10.14+ and custom PHP modules due to Apple specific issues. Read through https://php-osx.liip.ch/ extensively (specifically [here](https://github.com/liip/php-osx/issues/249)).
 
-Edit /etc/apache2/httpd.conf using a text editor (e.g. TextEdit). You must make two changes:
+Once PHP has been built successfully, edit /etc/apache2/httpd.conf using a text editor (e.g. TextEdit). You must make two changes:
 
-* Enabling php, by removing the initial hash symbol from the line beginning "#LoadModule php5_module" (pre-yosemite), or adding a similar line with the path to wherever you installed PHP, eg:
-    
-    LoadModule php5_module    /usr/local/php5-5.3.29-20141019-211753/libphp5.so
+* Enabling php, by removing the initial hash symbol from the line beginning "#LoadModule php5_module" (pre-yosemite), or adding a similar line with the path to wherever PHP has been installed, e.g.
 
-* Additional PHP extensions, like **php-sqlite3 php-gd php-curl php-xml php-intl php-json php-mbstring php-zip** may need to be installed.
+    LoadModule php7_module /usr/local/php5-7.2.9-20180821-074958/libphp7.so
+
+* The additional PHP extensions mentioned in the Linux instructions are provided as part of the LIIP build, except for Sodium. If you build PHP yourself, you should configure the compilation to include all of these extensions.
 
 * Adding a new Directory directive, by inserting: 
 
@@ -36,11 +38,13 @@ Alias /librarian /Users/yourusername/librarian/public
     # "Require all granted" opens access to everybody
 </Directory>
 ```
-* Don't forget to change "yourusername" to your actual user name. You can find out your user name by typing `whoami` in Terminal.
-* You may wish to alter who has access (e.g. to allow access from more IP numbers or domain names) - see the Apache [Authentication and Authorization HOWTO](https://httpd.apache.org/docs/2.4/howto/auth.html) for details.
-* Restart Apache, by typing `sudo apachectl restart` in Terminal
-* Install LibreOffice, Tesseract OCR, Ghostscript, and Poppler.
-* Download *I, Librarian* source for Linux and double-click the file to extract its contents. Rename the extracted directory to 'librarian' and move it to your folder.
+
+* Don't forget to change "yourusername" to your actual user name. You can find out your user name by typing `whoami` in Terminal.  
+* You may wish to alter who has access (e.g. to allow access from more IP numbers or domain names) - see the Apache [Authentication and Authorization HOWTO](https://httpd.apache.org/docs/2.4/howto/auth.html) for details.  
+* Restart Apache, by typing `sudo apachectl restart` in Terminal  
+* Install LibreOffice, Tesseract OCR, Ghostscript, and Poppler.  
+* Download *I, Librarian* source for Linux and double-click the file to extract its contents. Rename the extracted directory to 'librarian' and move it to your folder.  
+
 * Make sure that the directory is accessible to *Others*. Use the `Get Info` dialog of the *Sites* directory to change permissions for *Everyone* to access and read (alternatively, run `chmod o+r ~/Sites/` at the terminal). You also need to make sure *Everyone* has **Execute** permissions for your home directory.
 * Change the owner of the `data` sub-folder to the Apache user (_www for the default install). You can do this at the Terminal: `chown -R _www ~/librarian/data`.)
 * Open your web browser and go to [http://127.0.0.1/librarian](http://127.0.0.1/librarian).

--- a/README-Mac.md
+++ b/README-Mac.md
@@ -2,23 +2,25 @@
 
 ### Mac OS X manual installation
 
-If you are comfortable with Terminal and the command line, it is highly recommeded that you use [Homebrew](https://brew.sh/) or [MacPorts](https://www.macports.org/) to enable the use of UNIX based software on your Mac. In this case, the Linux instructions can be followed with paths modified as needed (Standard Macport installations live at /opt/local (e.g. /opt/local/var/www, not /var/www) while Brew lives at /usr/local )
+It is **highly** recommended that you use the package managers [Homebrew](https://brew.sh/) or [MacPorts](https://www.macports.org/) to enable the use of UNIX based software on your Mac. A Linux-like environment will be setup and the latest versions of the required software (web servers, PHP 7.2+, PHP extensions) can be easily downloaded and automatically compiled when necessary. The Linux instructions can then be followed with paths modified as needed (Standard Macport installations live at /opt/local (e.g. /opt/local/var/www, not /var/www) while Brew lives at /usr/local )
 
-The PHP extension Sodium will also be useful (php72-sodium, php73-sodium, or php74-sodium) as it is non-standard.
+The PHP extension Sodium is essential (php72-sodium, php73-sodium, or php74-sodium); it is not usually part of a standard build of PHP.
 
-If you want a standalone installation, you will need to have an Apache + PHP stack installed. Details may vary depending on which PHP stack you are using. One option is to install [MAMP](https://www.mamp.info/en/mac/) but it comes with MySQL as well. To configure a MAMP based installation, the Linux instructions can be followed.
+----
 
-If you want to use the Apache server OS X comes with, then a new version of PHP is needed. Prior to Mac OS 10.10.1 (Yosemite), the default install of Mac OS included Apache and PHP built with the GD library. However, the PHP installed with Yosemite does not include GD, so you will need to install one that does: it is simplest to use the one line installation instructions at [http://php-osx.liip.ch/](http://php-osx.liip.ch/.). PHP also needs to be upgraded to 7.2 or above.
+If you want a standalone installation, you will need to have an Apache + PHP stack installed. Details may vary depending on which PHP stack you are using. Two options aree [MAMP](https://www.mamp.info/en/mac/) and [XAMPP](https://xampp.site/) but they come with MySQL as well. To configure these installations, the Linux instructions can be followed. But missing PHP extensions will need to be downloaded (or compiled, like Sodium). Source for Sodium can be found at [PECL](https://pecl.php.net/).
 
-Warning: there are potential headaches with using the built-in Apache on 10.14+ and custom PHP modules due to Apple specific issues. Read through https://php-osx.liip.ch/ extensively (specifically [here](https://github.com/liip/php-osx/issues/249)).
+----
+
+If you want to use the Apache server OS X comes with, then a new version of PHP is needed. Below 10.15, the installed PHP is 7.1 or below - PHP 7.2 is a minimum. However, the PHP installed with 10.15 does not include some necessary extensions, so again you will need to compile something, e.g. Sodium. [PHPBrew](https://github.com/phpbrew/phpbrew) may be useful.
+
+Warning: there are potential headaches with using the built-in Apache on 10.14+ and custom PHP modules due to Apple code signing issues. Read through https://php-osx.liip.ch/ extensively (specifically [here](https://github.com/liip/php-osx/issues/249)).
 
 Once PHP has been built successfully, edit /etc/apache2/httpd.conf using a text editor (e.g. TextEdit). You must make two changes:
 
 * Enabling php, by removing the initial hash symbol from the line beginning "#LoadModule php5_module" (pre-yosemite), or adding a similar line with the path to wherever PHP has been installed, e.g.
 
     LoadModule php7_module /usr/local/php5-7.2.9-20180821-074958/libphp7.so
-
-* The additional PHP extensions mentioned in the Linux instructions are provided as part of the LIIP build, except for Sodium. If you build PHP yourself, you should configure the compilation to include all of these extensions.
 
 * Adding a new Directory directive, by inserting: 
 

--- a/README-Mac.md
+++ b/README-Mac.md
@@ -2,19 +2,19 @@
 
 ### Mac OS X manual installation
 
-It is **highly** recommended that you use the package managers [Homebrew](https://brew.sh/) or [MacPorts](https://www.macports.org/) to enable the use of UNIX based software on your Mac. A Linux-like environment will be setup and the latest versions of the required software (web servers, PHP 7.2+, PHP extensions) can be easily downloaded and automatically compiled when necessary. The Linux instructions can then be followed with paths modified as needed (Standard Macport installations live at /opt/local (e.g. /opt/local/var/www, not /var/www) while Brew lives at /usr/local )
+It is **HIGHLY** recommended that you use the package managers [Homebrew](https://brew.sh/) or [MacPorts](https://www.macports.org/) to enable the use of UNIX based software on your Mac. A Linux-like environment will be setup and the latest versions of the required software (web servers, PHP 7.2+, PHP extensions) can be easily downloaded and automatically compiled when/if necessary. The Linux instructions can then be followed with paths modified as needed (Standard Macport installations live at /opt/local (e.g. /opt/local/var/www, not /var/www) while Brew lives at /usr/local )
 
-The PHP extension Sodium is essential (php72-sodium, php73-sodium, or php74-sodium); it is not usually part of a standard build of PHP.
+The PHP extension Sodium is essential (php72-sodium, php73-sodium, or php74-sodium); it is not usually part of a standard build of PHP on OS X.
 
 ----
 
-If you want a standalone installation, you will need to have an Apache + PHP stack installed. Details may vary depending on which PHP stack you are using. Two options aree [MAMP](https://www.mamp.info/en/mac/) and [XAMPP](https://xampp.site/) but they come with MySQL as well. To configure these installations, the Linux instructions can be followed. But missing PHP extensions will need to be downloaded (or compiled, like Sodium). Source for Sodium can be found at [PECL](https://pecl.php.net/).
+If you want a standalone installation, you will need to have an Apache + PHP stack installed. Details may vary depending on which PHP stack you are using. Two options are [MAMP](https://www.mamp.info/en/mac/) and [XAMPP](https://xampp.site/) but they come with MySQL as well. To configure these installations, the Linux instructions can be followed. But missing PHP extensions will need to be downloaded (or compiled, like Sodium). Source for Sodium can be found at [PECL](https://pecl.php.net/).
 
 ----
 
 If you want to use the Apache server OS X comes with, then a new version of PHP is needed. Below 10.15, the installed PHP is 7.1 or below - PHP 7.2 is a minimum. However, the PHP installed with 10.15 does not include some necessary extensions, so again you will need to compile something, e.g. Sodium. [PHPBrew](https://github.com/phpbrew/phpbrew) may be useful.
 
-Warning: there are potential headaches with using the built-in Apache on 10.14+ and custom PHP modules due to Apple code signing issues. Read through https://php-osx.liip.ch/ extensively (specifically [here](https://github.com/liip/php-osx/issues/249)).
+Warning: there are potential headaches with using the built-in Apache on 10.14+ and custom PHP modules due to Apple code signing issues. Read through https://php-osx.liip.ch/ extensively (specifically [here](https://github.com/liip/php-osx/issues/249)). That premade build of PHP does not include Sodium either if you want to try it out.
 
 Once PHP has been built successfully, edit /etc/apache2/httpd.conf using a text editor (e.g. TextEdit). You must make two changes:
 

--- a/README.md
+++ b/README.md
@@ -120,14 +120,14 @@ location /library {
 
 PHP-FPM must also be configured. Locate where the configuration files are (e.g. /etc/php or /etc/php74) and 
 
-  1. In php.ini, ensure cgi.fix_pathinfo=1
-  1. In php.ini, enable the installed extensions in the ``Dynamic Extensions`` section (e.g. extension=curl)
+  1. Copy php.ini-production to php.ini (if it does not exist)
+  1. In php.ini, ensure cgi.fix_pathinfo=1 and configure important settings as needed (e.g. max_execution_time, max_input_time, memory_limit)
+  1. In php.ini, enable the installed extensions in the ``Dynamic Extensions`` section (e.g. extension=curl, no semicolon)
   1. Double check and configure the file php-fpm.conf as desired
   1. In the directory php-fpm.d, copy the example `www.conf.default` to `www.conf`
   1. Edit and configure this new file which sets up the www pool
      - `User` and `Group` should match the account running the PHP process
      - `listen` should equal the setting in nginx.conf (e.g. listen = 127.0.0.1:9000)
-     - Increasing the value of the `php_admin_value[memory_limit]` setting may be useful
 
 5. Restart the web server (and also php-fpm if needed)
 6. You can access your library in a browser at http://127.0.0.1/librarian

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 ## Contents
   - Automated installation using installers
   - Windows manual installation
-  - Linux manual installation
-  - Mac OS X manual installation
+  - [Linux manual installation](README-Linux.md)
+  - [Mac OS X manual installation](README-Mac.md)
   - First use
   - Un-installation
 
@@ -43,145 +43,6 @@ Alias /librarian "C:\I, Librarian\public"
   * Now you can access your library in a browser at http://127.0.0.1/librarian
   * *Optional.* You can install LibreOffice and Tesseract OCR to enable importing Office files and OCR, respectively. 
 
-### Linux manual installation
-1. If you did not use the DEB package, make sure you have installed these packages from repositories:
-  - Either of these web servers is recommended (you may run *I, Librarian* with any web server)
-    * **apache2 (may be named httpd)**
-    * **nginx**
-  - PHP (*I, Librarian* requires PHP 7.2+)
-    * For Apache, **php** and **libapache2-mod-php**
-    * For Nginx, **php-fpm** is recommended.
-  - PHP Extensions
-    * **php-sqlite3**: SQLite database for PHP.
-    * **php-gd**, **php-curl**, **php-intl**, **php-xml**, **php-json**, **php-mbstring**, **php-zip**: Other required PHP extensions.
-    * **php-ldap**: Required for using LDAP.
-  - External Utilities
-    * **poppler-utils**: required for PDF indexing and for the built-in PDF viewer.
-    * **ghostscript**: required for the built-in PDF viewer.
-    * **tesseract-ocr**: optional OCR.
-    * **libreoffice**: optional import of office files.
-
-2. If you are installing from the tar.gz, login as `root` or use `sudo`, and extract files
-  into a directory underneath the web server's root directory (e.g. `/var/www/librarian`). Example:
-
-```bash
-  tar -Jxf I-Librarian-*.tar.xz -C /var/www/librarian
-```
-3. Change the owner of the `data` sub-folder to the account that runs the web server. For Apache, this is usually `www-data`
-and for Nginx, `nobody`. Example:
-
-```bash
-  chown -R www-data:www-data /var/www/librarian/data
-```
-
-4. Configure the web server appropriately:
-
- * Apache: Insert a setting like this example into the configuration file:
-
-```apache_conf
-Alias /librarian "/var/www/librarian/public"
-<Directory "/var/www/librarian/public">
-    AllowOverride All
-    # Allow access from this computer
-    Require local
-    # Allow access from intranet computers
-    Require ip 10
-    Require ip 172.16 172.17 172.18 172.19 172.20
-    Require ip 172.21 172.22 172.23 172.24 172.25
-    Require ip 172.26 172.27 172.28 172.29 172.30 172.31
-    Require ip 192.168
-    # Insert Allow from directives here to allow access from the internet
-    # "Require all granted" opens access to everybody
-</Directory>
-```
-
-You may wish to alter who has access (e.g. to allow access from more IP numbers or domain names) - see the Apache [Authentication and Authorization HOWTO](https://httpd.apache.org/docs/2.4/howto/auth.html) for details.
-
- * Nginx: Add a block like this example to the `server` section:  (/var/www is assumed to be the root of the web server)
-
-```nginx.conf
-# if no directives, then access from all IPs is enabled
-allow 127.0.0.1;
-allow 10.0.0.0/8;
-allow 172.16.0.0/16;
-deny all;   # catch-all that denies everything else
-
-location /library {
-  # Ensures the URL `/library/` executes index.php
-  index index.php;
-
-  location ~ ^(.+\.php)(.*)$ {
-    alias /var/www/library/public;
-    fastcgi_split_path_info ^/library(.+\.php)(.*)$ ;
-    fastcgi_pass   127.0.0.1:9000;
-    include        fastcgi.conf;
-    fastcgi_param PATH_INFO $fastcgi_path_info;
-  }
-
-  # Maps the URL `/library/` to the correct file system location
-  alias /var/www/library/public;
-  try_files $uri $uri/ =404;
-}
-```
-
-PHP-FPM must also be configured. Locate where the configuration files are (e.g. /etc/php or /etc/php74) and 
-
-  1. Copy php.ini-production to php.ini (if it does not exist)
-  1. In php.ini, ensure cgi.fix_pathinfo=1 and configure important settings as needed (e.g. max_execution_time, max_input_time, memory_limit)
-  1. In php.ini, enable the installed extensions in the ``Dynamic Extensions`` section (e.g. extension=curl, no semicolon)
-  1. Double check and configure the file php-fpm.conf as desired
-  1. In the directory php-fpm.d, copy the example `www.conf.default` to `www.conf`
-  1. Edit and configure this new file which sets up the www pool
-     - `User` and `Group` should match the account running the PHP process
-     - `listen` should equal the setting in nginx.conf (e.g. listen = 127.0.0.1:9000)
-
-5. Restart the web server (and also php-fpm if needed)
-6. You can access your library in a browser at http://127.0.0.1/librarian
-
-
-### Mac OS X manual installation
-
-**These instructions may be obsolete. A contribution to update this section from an OS X user is welcome.**
-
-You will need to have an Apache + PHP stack installed. Details may vary depending on which PHP stack you are using.
-
-Prior to Mac OS 10.10.1 (Yosemite), the default install of Mac OS included Apache and PHP built with the GD library. However, the PHP installed with     Yosemite does not include GD, so you will need to install one that does:     it is simplest to use the one line installation instructions at [http://php-osx.liip.ch/](http://php-osx.liip.ch/.).
-
-Edit  /etc/apache2/httpd.conf using a text editor (e.g. TextEdit). You must make two changes:
-
-* Enabling php, by removing the initial hash symbol from the line beginning "#LoadModule php5_module" (pre-yosemite), or adding a similar line with the path to wherever you installed PHP, eg:
-    
-    LoadModule php5_module    /usr/local/php5-5.3.29-20141019-211753/libphp5.so
-
-* Additional PHP extensions, like **php-sqlite3 php-gd php-curl php-xml php-intl php-json php-mbstring php-zip** may need to be installed.
-
-* Adding a new Directory directive, by inserting: 
-
-```apache_conf
-Alias /librarian /Users/yourusername/librarian/public
-<Directory /Users/Yourusername/librarian/public>
-    AllowOverride All
-    # Allow access from this computer
-    Require local
-    # Allow access from intranet computers
-    Require ip 10
-    Require ip 172.16 172.17 172.18 172.19 172.20
-    Require ip 172.21 172.22 172.23 172.24 172.25
-    Require ip 172.26 172.27 172.28 172.29 172.30 172.31
-    Require ip 192.168
-    # Insert Allow from directives here to allow access from the internet
-    # "Require all granted" opens access to everybody
-</Directory>
-```
-* Don't forget to change "yourusername" to your actual user name. You can find out your user name by typing `whoami` in Terminal.
-* You may wish to alter who has access (e.g. to allow access from more IP numbers or domain names) - see the Apache [Authentication and Authorization HOWTO](https://httpd.apache.org/docs/2.4/howto/auth.html) for details.
-* Restart Apache, by typing `sudo apachectl restart` in Terminal
-* Install LibreOffice, Tesseract OCR, Ghostscript, and Poppler.
-* Download *I, Librarian* source for Linux and double-click the file to extract its contents. Rename the extracted directory to 'librarian' and move it to your folder.
-* Make sure that the directory is accessible to *Others*. Use the `Get Info` dialog of the *Sites* directory to change permissions for *Everyone* to access and read (alternatively, run `chmod o+r ~/Sites/` at the terminal). You also need to make sure *Everyone* has **Execute** permissions for your home directory.
-* Change the owner of the `data` sub-folder to the Apache user (_www for the default install). You can do this at the Terminal: `chown -R _www ~/librarian/data`.)
-* Open your web browser and go to [http://127.0.0.1/librarian](http://127.0.0.1/librarian).
-
 ### First use
 * Note on security: These installation instructions allow access to your library only from local computer
   or an internal network.
@@ -196,5 +57,6 @@ Alias /librarian /Users/yourusername/librarian/public
 ### Un-installation
 * If you used the DEB package, execute the `uninstall.sh` un-installer.
 * Otherwise un-install all programs that you installed solely to use *I, Librarian*.
-* These may include Apache and PHP. **Note: You might have other programs using these. Only remove if sure.**
+* These may include Apache, Nginx, and PHP - using package managers like Apt, Homebrew, or Macports will make this task easier. **Note: You might have other programs using these. Only remove if sure.**
 * Delete *I, Librarian* directory.
+

--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ You may wish to alter who has access (e.g. to allow access from more IP numbers 
  * Nginx: Add a block like this example to the `server` section:  (/var/www is assumed to be the root of the web server)
 
 ```nginx.conf
+# if no directives, then access from all IPs is enabled
+allow 127.0.0.1;
+allow 10.0.0.0/8;
+allow 172.16.0.0/16;
+deny all;   # catch-all that denies everything else
+
 location /library {
   # Ensures the URL `/library/` executes index.php
   index index.php;
@@ -131,6 +137,7 @@ PHP-FPM must also be configured. Locate where the configuration files are (e.g. 
 
 5. Restart the web server (and also php-fpm if needed)
 6. You can access your library in a browser at http://127.0.0.1/librarian
+
 
 ### Mac OS X manual installation
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ and PHP for you. If you don't want that, follow the instructions below to instal
 
 ### Windows manual installation
   * A running *Apache 2.4+* and *PHP 7.2+* are required. Install them using a Windows installer like WAMP.
-  * Edit Apache configuration file (httpd.conf). Append this at the end using Notepad:
+  * Edit Apache configuration file (httpd.conf). Append this and edit appropriately at the end using Notepad:
 
 ```apache_conf
 Alias /librarian "C:\I, Librarian\public"
@@ -44,27 +44,39 @@ Alias /librarian "C:\I, Librarian\public"
   * *Optional.* You can install LibreOffice and Tesseract OCR to enable importing Office files and OCR, respectively. 
 
 ### Linux manual installation
-* If you did not use the DEB package, make sure you have installed these packages from repositories:
-  - **apache2 (may be named httpd)**: a web server (you may run *I, Librarian* with a different web server).
-  - **php libapache2-mod-php**: *I, Librarian* requires PHP +7.2.
-  - **php-sqlite3**: SQLite database for PHP.
-  - **php-gd php-curl php-xml php-intl php-json php-mbstring php-zip**: Other required PHP extensions.
-  - **poppler-utils**: required for PDF indexing and for the built-in PDF viewer.
-  - **ghostscript**: required for the built-in PDF viewer.
-  - **tesseract-ocr**: optional OCR.
-  - **libreoffice**: optional import of office files.
-* If you are installing from the tar.gz, login as `root` or use `sudo`, and extract files
-  into e.g. `/var/www/librarian` directory in your web sever's root directory. Example:
+1. If you did not use the DEB package, make sure you have installed these packages from repositories:
+  - Either of these web servers is recommended (you may run *I, Librarian* with any web server)
+    * **apache2 (may be named httpd)**
+    * **nginx**
+  - PHP (*I, Librarian* requires PHP 7.2+)
+    * For Apache, **php** and **libapache2-mod-php**
+    * For Nginx, **php-fpm** is recommended.
+  - PHP Extensions
+   * **php-sqlite3**: SQLite database for PHP.
+   * **php-gd**, **php-curl**, **php-intl**, **php-xml**, **php-json**, **php-mbstring**, **php-zip**: Other required PHP extensions.
+   * **php-ldap**: Required for using LDAP.
+  - External Utilities
+   * **poppler-utils**: required for PDF indexing and for the built-in PDF viewer.
+   * **ghostscript**: required for the built-in PDF viewer.
+   * **tesseract-ocr**: optional OCR.
+   * **libreoffice**: optional import of office files.
+
+1. If you are installing from the tar.gz, login as `root` or use `sudo`, and extract files
+  into a directory underneath the web server's root directory (e.g. `/var/www/librarian`). Example:
 
 ```bash
   tar -Jxf I-Librarian-*.tar.xz -C /var/www/librarian
 ```
-* Change the owner of the `data` sub-folder to Apache. Example:
+* Change the owner of the `data` sub-folder to the account that runs the web server. For Apache, this is usually `www-data`
+and for Nginx, `nobody`. Example:
 
 ```bash
   chown -R www-data:www-data /var/www/librarian/data
 ```
-* Insert a setting like this example into your Apache configuration file:
+
+* Configure the web server appropriately:
+
+* Apache: Insert a setting like this example into your Apache configuration file:
 
 ```apache_conf
 Alias /librarian "/var/www/librarian/public"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ and PHP for you. If you don't want that, follow the instructions below to instal
 
 ### Windows manual installation
   * A running *Apache 2.4+* and *PHP 7.2+* are required. Install them using a Windows installer like WAMP.
-  * Edit Apache configuration file (httpd.conf). Append this and edit appropriately at the end using Notepad:
+  * Edit Apache configuration file (httpd.conf). Append this at the end using Notepad and edit as needed:
 
 ```apache_conf
 Alias /librarian "C:\I, Librarian\public"
@@ -52,31 +52,31 @@ Alias /librarian "C:\I, Librarian\public"
     * For Apache, **php** and **libapache2-mod-php**
     * For Nginx, **php-fpm** is recommended.
   - PHP Extensions
-   * **php-sqlite3**: SQLite database for PHP.
-   * **php-gd**, **php-curl**, **php-intl**, **php-xml**, **php-json**, **php-mbstring**, **php-zip**: Other required PHP extensions.
-   * **php-ldap**: Required for using LDAP.
+    * **php-sqlite3**: SQLite database for PHP.
+    * **php-gd**, **php-curl**, **php-intl**, **php-xml**, **php-json**, **php-mbstring**, **php-zip**: Other required PHP extensions.
+    * **php-ldap**: Required for using LDAP.
   - External Utilities
-   * **poppler-utils**: required for PDF indexing and for the built-in PDF viewer.
-   * **ghostscript**: required for the built-in PDF viewer.
-   * **tesseract-ocr**: optional OCR.
-   * **libreoffice**: optional import of office files.
+    * **poppler-utils**: required for PDF indexing and for the built-in PDF viewer.
+    * **ghostscript**: required for the built-in PDF viewer.
+    * **tesseract-ocr**: optional OCR.
+    * **libreoffice**: optional import of office files.
 
-1. If you are installing from the tar.gz, login as `root` or use `sudo`, and extract files
+2. If you are installing from the tar.gz, login as `root` or use `sudo`, and extract files
   into a directory underneath the web server's root directory (e.g. `/var/www/librarian`). Example:
 
 ```bash
   tar -Jxf I-Librarian-*.tar.xz -C /var/www/librarian
 ```
-* Change the owner of the `data` sub-folder to the account that runs the web server. For Apache, this is usually `www-data`
+3. Change the owner of the `data` sub-folder to the account that runs the web server. For Apache, this is usually `www-data`
 and for Nginx, `nobody`. Example:
 
 ```bash
   chown -R www-data:www-data /var/www/librarian/data
 ```
 
-* Configure the web server appropriately:
+4. Configure the web server appropriately:
 
-* Apache: Insert a setting like this example into your Apache configuration file:
+ * Apache: Insert a setting like this example into the configuration file:
 
 ```apache_conf
 Alias /librarian "/var/www/librarian/public"
@@ -94,9 +94,12 @@ Alias /librarian "/var/www/librarian/public"
     # "Require all granted" opens access to everybody
 </Directory>
 ```
-* You may wish to alter who has access (e.g. to allow access from more IP numbers or domain names) - see the Apache [Authentication and Authorization HOWTO](https://httpd.apache.org/docs/2.4/howto/auth.html) for details.
-* Restart the server.
-* You can access your library in a browser at http://127.0.0.1/librarian
+You may wish to alter who has access (e.g. to allow access from more IP numbers or domain names) - see the Apache [Authentication and Authorization HOWTO](https://httpd.apache.org/docs/2.4/howto/auth.html) for details.
+
+
+
+ * Restart the web server.
+ * You can access your library in a browser at http://127.0.0.1/librarian
 
 ### Mac OS X manual installation
 

--- a/README.md
+++ b/README.md
@@ -123,11 +123,11 @@ PHP-FPM must also be configured. Locate where the configuration files are (e.g. 
   1. In php.ini, ensure cgi.fix_pathinfo=1
   1. In php.ini, enable the installed extensions in the ``Dynamic Extensions`` section (e.g. extension=curl)
   1. Double check and configure the file php-fpm.conf as desired
-  1. In the directory php-fpm.d, copy the example ``www.conf.default` to `www.conf`
+  1. In the directory php-fpm.d, copy the example `www.conf.default` to `www.conf`
   1. Edit and configure this new file which sets up the www pool
-    * `User` and `Group` should match the account running the PHP process
-    * `listen` should equal the setting in nginx.conf (e.g. listen = 127.0.0.1:9000)
-    * Increasing the value of the `php_admin_value[memory_limit]` setting may be useful
+     - `User` and `Group` should match the account running the PHP process
+     - `listen` should equal the setting in nginx.conf (e.g. listen = 127.0.0.1:9000)
+     - Increasing the value of the `php_admin_value[memory_limit]` setting may be useful
 
 5. Restart the web server (and also php-fpm if needed)
 6. You can access your library in a browser at http://127.0.0.1/librarian

--- a/classes/security/encryption.php
+++ b/classes/security/encryption.php
@@ -44,11 +44,21 @@ final class Encryption {
      */
     public function hashPassword(string $password): string {
 
-        return password_hash($password, PASSWORD_ARGON2I, [
-            'memory_cost' => 10000,
-            'threads'     => 1,
-            'time_cost'   => $this->cost
-        ]);
+        if (defined('PASSWORD_ARGON2I')) {
+
+            return password_hash($password, PASSWORD_ARGON2I, [
+                'memory_cost' => 10000,
+                'threads'     => 1,
+                'time_cost'   => $this->cost
+            ]);
+
+        } else {
+
+            return password_hash($password, PASSWORD_DEFAULT, [
+                'cost' => 10
+            ]);
+
+        }
     }
 
     /**
@@ -73,15 +83,27 @@ final class Encryption {
      */
     public function rehashPassword(string $password, string $storedPassword) {
 
-        if (password_needs_rehash($storedPassword, PASSWORD_ARGON2I, [
-            'memory_cost' => 10000,
-            'threads'     => 1,
-            'time_cost'   => $this->cost
-        ]) === true) {
+        if (defined('PASSWORD_ARGON2I')) {
 
-            return $this->hashPassword($password);
+           $rehash = password_needs_rehash($storedPassword, PASSWORD_ARGON2I, [
+               'memory_cost' => 10000,
+               'threads'     => 1,
+               'time_cost'   => $this->cost
+           ]);
+
+        } else {
+
+           $rehash = password_needs_rehash($storedPassword, PASSWORD_DEFAULT, [
+               'cost' => 10
+           ]);
+
         }
 
+        if ($rehash) {
+
+            return $this->hashPassword($password);
+    
+        }
         return false;
     }
 

--- a/classes/security/encryption.php
+++ b/classes/security/encryption.php
@@ -44,21 +44,11 @@ final class Encryption {
      */
     public function hashPassword(string $password): string {
 
-        if (defined('PASSWORD_ARGON2I')) {
-
-            return password_hash($password, PASSWORD_ARGON2I, [
-                'memory_cost' => 10000,
-                'threads'     => 1,
-                'time_cost'   => $this->cost
-            ]);
-
-        } else {
-
-            return password_hash($password, PASSWORD_DEFAULT, [
-                'cost' => 10
-            ]);
-
-        }
+        return password_hash($password, PASSWORD_ARGON2I, [
+            'memory_cost' => 10000,
+            'threads'     => 1,
+            'time_cost'   => $this->cost
+        ]);
     }
 
     /**
@@ -83,27 +73,15 @@ final class Encryption {
      */
     public function rehashPassword(string $password, string $storedPassword) {
 
-        if (defined('PASSWORD_ARGON2I')) {
-
-           $rehash = password_needs_rehash($storedPassword, PASSWORD_ARGON2I, [
-               'memory_cost' => 10000,
-               'threads'     => 1,
-               'time_cost'   => $this->cost
-           ]);
-
-        } else {
-
-           $rehash = password_needs_rehash($storedPassword, PASSWORD_DEFAULT, [
-               'cost' => 10
-           ]);
-
-        }
-
-        if ($rehash) {
+        if (password_needs_rehash($storedPassword, PASSWORD_ARGON2I, [
+            'memory_cost' => 10000,
+            'threads'     => 1,
+            'time_cost'   => $this->cost
+        ]) === true) {
 
             return $this->hashPassword($password);
-    
         }
+
         return false;
     }
 


### PR DESCRIPTION
Hi,

I think I'm finished, at least this is my version of the instructions. I tried to address common problems with configuring PHP-FPM as well. I can get a little verbose and README.md was looking too long, so I divided it up. 

Unfortunately, I just don't see any way to easily setup I-Librarian on a Mac for non-technically inclined people (without the use of Homebrew/Macports) - Sodium/ARGON2 support is not prebuilt-in to anything for Mac or available like the Windows DLLs are. It may be in the core now, but one still has to explicitly enable it and install libsodium, etc.

Let me know if you want anything changed. A simple script invoking Homebrew or macports would be a possible solution towards an "easy install" but I assume the non-technical user base is mostly Windows.

Doug
 