### PR TITLE
Bug showing January for all new entries fixed.

### DIFF
--- a/classes/export/bibtex.php
+++ b/classes/export/bibtex.php
@@ -161,8 +161,9 @@ class Bibtex {
                 $output .= $this->prettyTag('year') . '{' . $year . '},' . PHP_EOL;
 
                 $month = (int) substr($item[ItemMeta::COLUMN['PUBLICATION_DATE']], 5, 2);
+                $day = (int) substr($item[ItemMeta::COLUMN['PUBLICATION_DATE']], 8, 2);
 
-                if ($month > 0 && $month <= 12) {
+                if ($month > 0 && $month <= 12 && ($month != 1 || $day != 1)) {
 
                     $output .= $this->prettyTag('month') . '{' . $month . '},' . PHP_EOL;
                 }


### PR DESCRIPTION
I recognized that the current version of I librarian automatically saves e.g. "2020-01-01" when only the year, so here 2020, is given for a new entry. When exporting to bibtex this leads to a similar bug as the one I fixed some time ago with the export of month 0. Now for all new entries without a date the month January is exported and the literature is cited e.g. as "Jan. 2020", which is not correct. I fixed this by omitting the month if the publication date is the first of January which should be very unlikely for real publication dates and even if accidentally the month of such a publication is not shown in the end, this is much better than a lot of wrong January entries in the bibliography.