### PR TITLE
LDAP User-Filter now configurable.

### DIFF
--- a/config/ilibrarian-default.ini
+++ b/config/ilibrarian-default.ini
@@ -81,6 +81,12 @@ ldap_username_attr = "uid"
 ;ldap_userlogin_attr = "sAMAccountName"
 ldap_userlogin_attr = "uid"
 
+; LDAP Filter to additionally restrict the user search, and with (ldap_userlogin_attr = user)
+; ldap_user_filter = "(|(objectClass=user)(objectClass=iNetOrgPerson))"
+ldap_user_filter = "(|(objectClass=user)(objectClass=iNetOrgPerson))"
+
+
+
 ;
 ; Authorization. If the below options are provided, a group affiliation
 ; is checked (admins vs. users) and permissions are set accordingly.
@@ -90,6 +96,9 @@ ldap_userlogin_attr = "uid"
 ; Group relative search base without basedn.
 ;ldap_group_rdn = "ou=groups"
 ldap_group_rdn = ""
+
+; Admin users, comma separated list, if not set the LDAP selection is used
+; ldap_admin_users = nobody1, nobody2
 
 ; Admin group common name.
 ;ldap_admingroup_cn = "cn=admins"


### PR DESCRIPTION
I added the following stuff to the LDAP-Auth module since it was not configurable as we need it:

### New Options in ilibrarian.ini
- **ldap_user_filter** - define a user supplied filter for the LDAP objects. This filter is combined with "&" with the username
- **ldap_admin_users** - comma separated list of users that obtain admin rights. If this value is set the  **ldap_admingroup_cn** is ignored. 

### Bugfix
- Treat errors thrown by ldap_bind as incorrect password. 
